### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Loki MCP Server is a [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/mcp) interface for querying Grafana Loki logs using `logcli`. The server enables AI assistants to access and analyze log data from Loki directly.
 
+<a href="https://glama.ai/mcp/servers/@ghrud92/loki-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ghrud92/loki-mcp/badge" alt="Loki Server MCP server" />
+</a>
+
 ## Features
 
 - Query Loki logs with full LogQL support


### PR DESCRIPTION
This PR adds a badge for the [Loki MCP Server](https://glama.ai/mcp/servers/@ghrud92/loki-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ghrud92/loki-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ghrud92/loki-mcp/badge" alt="Loki Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.